### PR TITLE
Allow program to work without flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ echo "EOF"
 $ export URL="https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 
 # Experience pleasure by using the catslack!
-$ ./myCoolTestScript.sh | catslack -url $URL
+$ ./myCoolTestScript.sh | catslack
 ```

--- a/main.go
+++ b/main.go
@@ -55,6 +55,9 @@ func init() {
 
 	// Parse all flags
 	flag.Parse()
+	if slackURL == "" {
+		slackURL = os.Getenv("URL")
+	}
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -55,8 +55,9 @@ func init() {
 
 	// Parse all flags
 	flag.Parse()
+	// If no flag was given, use the $CATSLACK_URL env var.
 	if slackURL == "" {
-		slackURL = os.Getenv("URL")
+		slackURL = os.Getenv("CATSLACK_URL")
 	}
 }
 
@@ -64,8 +65,9 @@ func main() {
 
 	// Exit if not passed a url
 	if slackURL == "" {
-		fmt.Println("Must pass a working Slack integration URL using the `-url` flag.")
-		return
+		fmt.Println("Must pass a working Slack integration URL using the `-url` flag")
+		fmt.Println("or by setting the $CATSLACK_URL env variable.")
+		os.Exit(1)
 	}
 
 	// Start reading `stdin`


### PR DESCRIPTION
If env var $URL is set, there is no need for the -url.
-url will override $URL if set.
